### PR TITLE
Add anticipated departures

### DIFF
--- a/src/components/BusDepartureDetails.js
+++ b/src/components/BusDepartureDetails.js
@@ -54,8 +54,8 @@ class BusDepartureDetails extends React.Component {
     }
     if (prevState.lastKnownStopsAway !== this.state.lastKnownStopsAway) {
       // ["1 stop away", "< 1 stop away"]
-      console.log([prevState.lastKnownStopsAway, this.state.lastKnownStopsAway])
-      console.log(this.props.anticipatedDepVehicleRef)
+      // console.log([prevState.lastKnownStopsAway, this.state.lastKnownStopsAway])
+      // console.log(this.props.anticipatedDepVehicleRef)
       let prevStopsAway = prevState.lastKnownStopsAway
       let currentStopsAway = this.state.lastKnownStopsAway
       let orderedSequence = ["< 1 stop away", "approaching", "at stop"]
@@ -76,6 +76,7 @@ class BusDepartureDetails extends React.Component {
 
   render () {
     const { recentDepartures, previousDepartures, stopsAway, minutesAway, progressStatus, recents, recentDepText, recentHeadways, recentVehicleRefs, yesterday, previousHeadways, previousVehicleRefs, yesterdayLabel, recentsRating, prevDeparturesRating, overallRating, allowableHeadwayMin, loadingState } = this.props
+    const vehicleNum = this.state.prevAnticipatedVehicleRef
     var historicalDeparturesLoading;
 
     historicalDeparturesLoading = (loadingState.loading && loadingState.features.has(HISTORICAL_DEPARTURES))
@@ -86,6 +87,7 @@ class BusDepartureDetails extends React.Component {
           stopsAway={stopsAway}
           minutesAway={minutesAway}
           progressStatus={progressStatus}
+          vehicleNum={vehicleNum}
         />
         {historicalDeparturesLoading &&
           <RoundRect className='loading'>

--- a/src/components/BusDepartureDetails.js
+++ b/src/components/BusDepartureDetails.js
@@ -13,7 +13,8 @@ class BusDepartureDetails extends React.Component {
     this.scrollRef = React.createRef();  // Create a reference so that later, we can read & write scrollLeft
 
     this.state = {
-      lastKnownStopsAway: 'Unknown'
+      lastKnownStopsAway: 'Unknown',
+      prevAnticipatedVehicleRef: null,
     }
   }
 
@@ -42,11 +43,19 @@ class BusDepartureDetails extends React.Component {
     // This way we can display departures immediately, instead of after 2+ minutes.
 
     if (this.props.stopsAway !== "Unknown" && this.props.stopsAway !== "No vehicles found" && prevProps.stopsAway !== this.props.stopsAway) {
-      this.setState({lastKnownStopsAway: this.props.stopsAway})
+      this.setState({
+        lastKnownStopsAway: this.props.stopsAway,
+      });
+      if (!this.state.prevAnticipatedVehicleRef) {
+        this.setState({
+          prevAnticipatedVehicleRef: this.props.anticipatedDepVehicleRef,
+        })
+      }
     }
     if (prevState.lastKnownStopsAway !== this.state.lastKnownStopsAway) {
       // ["1 stop away", "< 1 stop away"]
       console.log([prevState.lastKnownStopsAway, this.state.lastKnownStopsAway])
+      console.log(this.props.anticipatedDepVehicleRef)
       let prevStopsAway = prevState.lastKnownStopsAway
       let currentStopsAway = this.state.lastKnownStopsAway
       let orderedSequence = ["< 1 stop away", "approaching", "at stop"]
@@ -55,8 +64,11 @@ class BusDepartureDetails extends React.Component {
         let currIndex = orderedSequence.indexOf(currentStopsAway) // 0, 1, 2, or -1 if not found
         if (currIndex < prevIndex) {
           // then we can assume currentStopsAway and prevStopsAway refer to different vehicles; therefore, create the anticipated departure.
-          this.props.createAnticipatedDeparture(prevProps.anticipatedDepVehicleRef)
-          this.forceUpdate()
+          this.props.createAnticipatedDeparture(this.state.prevAnticipatedVehicleRef)
+          this.setState({
+            prevAnticipatedVehicleRef: this.props.anticipatedDepVehicleRef,
+          })
+          console.log('setting state', {prevAnticipatedVehicleRef: this.state.prevAnticipatedVehicleRef})
         }
       }
     }

--- a/src/components/BusDepartureDetails.js
+++ b/src/components/BusDepartureDetails.js
@@ -49,8 +49,12 @@ class BusDepartureDetails extends React.Component {
       console.log([prevState.lastKnownStopsAway, this.state.lastKnownStopsAway])
       let prevStopsAway = prevState.lastKnownStopsAway
       let currentStopsAway = this.state.lastKnownStopsAway
-      if (prevStopsAway === "approaching" || prevStopsAway === "at stop") {
-        if (currentStopsAway !== "at stop") {
+      let orderedSequence = ["< 1 stop away", "approaching", "at stop"]
+      if (orderedSequence.includes(prevStopsAway)) {
+        let prevIndex = orderedSequence.indexOf(prevStopsAway) // 0, 1, or 2
+        let currIndex = orderedSequence.indexOf(currentStopsAway) // 0, 1, 2, or -1 if not found
+        if (currIndex < prevIndex) {
+          // then we can assume currentStopsAway and prevStopsAway refer to different vehicles; therefore, create the anticipated departure.
           this.props.createAnticipatedDeparture()
         }
       }

--- a/src/components/BusDepartureDetails.js
+++ b/src/components/BusDepartureDetails.js
@@ -40,7 +40,6 @@ class BusDepartureDetails extends React.Component {
     // If it looks like a bus departed but the departure hasn't yet been created and returned from the API,
     // we can create an 'anticipated' departure which will live in our Redux store but nowhere else.
     // This way we can display departures immediately, instead of after 2+ minutes.
-    // The next time we call the API and get departure data, the 'anticipated' departure will be overwritten.
 
     if (this.props.stopsAway !== "Unknown" && this.props.stopsAway !== "No vehicles found" && prevProps.stopsAway !== this.props.stopsAway) {
       this.setState({lastKnownStopsAway: this.props.stopsAway})

--- a/src/components/BusDepartureDetails.js
+++ b/src/components/BusDepartureDetails.js
@@ -55,7 +55,8 @@ class BusDepartureDetails extends React.Component {
         let currIndex = orderedSequence.indexOf(currentStopsAway) // 0, 1, 2, or -1 if not found
         if (currIndex < prevIndex) {
           // then we can assume currentStopsAway and prevStopsAway refer to different vehicles; therefore, create the anticipated departure.
-          this.props.createAnticipatedDeparture()
+          this.props.createAnticipatedDeparture(prevProps.anticipatedDepVehicleRef)
+          this.forceUpdate()
         }
       }
     }

--- a/src/components/BusStopDetailPage.js
+++ b/src/components/BusStopDetailPage.js
@@ -64,14 +64,6 @@ class BusStopDetailPage extends Component {
     })
   }
 
-  // componentDidUpdate(prevProps, prevState) {
-  //   if (this.props.historicalDepartures.items.length < 1 || prevProps.historicalDepartures.items.length < 1) return;
-  //   if (prevProps.historicalDepartures.items[0].recents[0] !== this.props.historicalDepartures.items[0].recents[0]) {
-  //     console.log('reinserting anticipated departures', this.props.anticipatedDepartures)
-  //     this.props.insertAnticipatedDepartures({anticipatedDepartures: this.props.anticipatedDepartures.items})
-  //   }
-  // }
-
   createAnticipatedDeparture = (vehicleRef) => {
     console.log('create anticipated departure!')
     // {

--- a/src/components/BusStopDetailPage.js
+++ b/src/components/BusStopDetailPage.js
@@ -16,31 +16,25 @@ class BusStopDetailPage extends Component {
   componentDidMount() {
 
     const lineRef = this.props.match.params.id
-    const stopId = this.props.match.params.stop
+    const stopRef = this.props.match.params.stop
 
     // If we're just loading the app from this page, get all our data.
     if (!this.props.stopLists.firstRequestSent) {
       this.props.fetchStopList(lineRef)
     }
     if (!this.props.realTimeDetails.firstRequestSent) {
-      this.props.fetchRealTimeDetail(stopId)
+      this.props.fetchRealTimeDetail(stopRef)
     }
     if (!this.props.historicalDepartures.firstRequestSent) {
-      this.props.fetchHistoricalDeparture({
-      stopRef: stopId,
-      lineRef: lineRef,
-      })
+      this.props.fetchHistoricalDeparture({ stopRef, lineRef })
     }
     this.reinsertAnticipatedDepartures()
 
     // Poll the API regularly to update data
     // Realtime data: every 9 seconds
-    this.getNextRealtimeData = setInterval(this.props.fetchRealTimeDetail, 9000, stopId)
+    this.getNextRealtimeData = setInterval(this.props.fetchRealTimeDetail, 9000, stopRef)
     // Historical departures: every minute (matches how often the API creates them)
-    this.getNextHistoricalDepartures = setInterval(this.props.fetchHistoricalDeparture, 60000, {
-      stopRef: stopId,
-      lineRef: lineRef,
-    })
+    this.getNextHistoricalDepartures = setInterval(this.props.fetchHistoricalDeparture, 60000, { stopRef, lineRef })
     // have to put this in its own function so that this.props.anticipatedDepartures.items is up to date.
     this.getNextAnticipatedDepartures = setInterval(this.reinsertAnticipatedDepartures, 9000);
   }
@@ -116,7 +110,7 @@ class BusStopDetailPage extends Component {
   getHeaderAndRealTimeData = () => {
 
     const lineRef = this.props.match.params.id
-    const stopId = this.props.match.params.stop
+    const stopRef = this.props.match.params.stop
 
     var routeData, routeName, stopName, routeDirection;
     var stopsAwayText, minutesAwayText, expectedDepartureTime, progressStatusText;
@@ -134,7 +128,7 @@ class BusStopDetailPage extends Component {
         routeName = routeRef.shortName
       }
       // get stop name
-      let stopRef = routeData.references.stops.find((stopRef) => stopRef.id === stopId)
+      let stopRef = routeData.references.stops.find((stopRef) => stopRef.id === stopRef)
       if (stopRef) {
         stopName = stopRef.name
       }
@@ -143,7 +137,7 @@ class BusStopDetailPage extends Component {
     // REAL-TIME DATA
     var anticipatedDepVehicleRef;
     // realTimeDetails: Filter to just the stopRef we care about
-    let rtdRefs = this.props.realTimeDetails.items.filter((rtdRef) => rtdRef.stopRef === stopId);
+    let rtdRefs = this.props.realTimeDetails.items.filter((rtdRef) => rtdRef.stopRef === stopRef);
     // Now find the first vehicle that matches our lineRef
     let foundRtdRef = rtdRefs.find((rtdRef) => rtdRef.lineRef === lineRef);
     if (!foundRtdRef) {
@@ -172,7 +166,7 @@ class BusStopDetailPage extends Component {
       routeName,
       lineRef,
       routeDirection,
-      stopId,
+      stopRef,
       stopName,
       stopsAwayText,
       minutesAwayText,
@@ -184,7 +178,7 @@ class BusStopDetailPage extends Component {
   getDepartureData = () => {
 
     const lineRef = this.props.match.params.id
-    const stopId = this.props.match.params.stop
+    const stopRef = this.props.match.params.stop
 
     // HISTORICAL DEPARTURE DATA
     var recents = []
@@ -196,7 +190,7 @@ class BusStopDetailPage extends Component {
     var yesterdayLabel, recentHeadways, previousHeadways, previousTimestamps, recentDepText;
     var recentsRating, prevDeparturesRating, overallRating;
 
-    let hdRef = this.props.historicalDepartures.items.find((dep) => dep.line_ref === lineRef && dep.stop_ref === stopId)
+    let hdRef = this.props.historicalDepartures.items.find((dep) => dep.line_ref === lineRef && dep.stop_ref === stopRef)
     if (hdRef) {
       // Recent departure data
       recentDepartures = hdRef.recents
@@ -253,7 +247,7 @@ class BusStopDetailPage extends Component {
       routeName,
       lineRef,
       routeDirection,
-      stopId,
+      stopRef,
       stopName,
       stopsAwayText,
       minutesAwayText,
@@ -277,7 +271,6 @@ class BusStopDetailPage extends Component {
       overallRating,
     } = this.getDepartureData()
 
-
     return (
       <div className='bus-stop-detail'>
         <BusRouteHeader
@@ -285,7 +278,7 @@ class BusStopDetailPage extends Component {
           routeName={routeName}
           routeId={lineRef}
           routeDirection={routeDirection}
-          stopNum={stopId}
+          stopNum={stopRef}
           stopName={stopName}
         />
         <BusDepartureDetails

--- a/src/components/BusStopDetailPage.js
+++ b/src/components/BusStopDetailPage.js
@@ -70,7 +70,7 @@ class BusStopDetailPage extends Component {
     this.props.addAnticipatedDeparture({
       anticipatedDeparture: {
         id: null,
-        stop_ref: "MTA_401905",
+        stop_ref: "MTA_401924",
         line_ref: "MTA NYCT_M86+",
         departure_time: "2019-03-10T14:14:01.000Z",
         created_at: null,

--- a/src/components/BusStopDetailPage.js
+++ b/src/components/BusStopDetailPage.js
@@ -13,13 +13,6 @@ import Loader from './Loader'
 
 class BusStopDetailPage extends Component {
 
-  constructor(props) {
-    super(props)
-    this.state = {
-      currentHeadway: 0,
-    }
-  }
-
   componentDidMount() {
 
     const routeId = this.props.match.params.id
@@ -120,14 +113,10 @@ class BusStopDetailPage extends Component {
 
   }
 
-  render() {
-    if (this.props.ui.loading && this.props.realTimeDetails.items.length === 0) {
-      return <Loader absolute />
-    }
+  getHeaderAndRealTimeData = () => {
 
     const routeId = this.props.match.params.id
     const stopId = this.props.match.params.stop
-    const loadingState = this.props.ui
 
     var routeData, routeName, stopName, routeDirection;
     var stopsAwayText, minutesAwayText, expectedDepartureTime, progressStatusText;
@@ -179,6 +168,24 @@ class BusStopDetailPage extends Component {
 
     }
 
+    return {
+      routeName,
+      routeId,
+      routeDirection,
+      stopId,
+      stopName,
+      stopsAwayText,
+      minutesAwayText,
+      progressStatusText,
+      anticipatedDepVehicleRef,
+    }
+  }
+
+  getDepartureData = () => {
+
+    const routeId = this.props.match.params.id
+    const stopId = this.props.match.params.stop
+
     // HISTORICAL DEPARTURE DATA
     var recents = []
     var yesterday = []
@@ -186,7 +193,7 @@ class BusStopDetailPage extends Component {
     var previousDepartures = []
     var recentVehicleRefs = []
     var previousVehicleRefs = []
-    var prevText, recentHeadways, previousHeadways, previousTimestamps, recentDepText;
+    var yesterdayLabel, recentHeadways, previousHeadways, previousTimestamps, recentDepText;
     var recentsRating, prevDeparturesRating, overallRating;
 
     let hdRef = this.props.historicalDepartures.items.find((dep) => dep.line_ref === routeId && dep.stop_ref === stopId)
@@ -215,9 +222,61 @@ class BusStopDetailPage extends Component {
       previousHeadways.pop()
       previousVehicleRefs = hdRef.prev_departures.map((hd) => hd.vehicle_ref.split('_')[1])
       yesterday = previousTimestamps.map((timeStamp) => moment(timeStamp).format('LT'))
-      prevText = hdRef.prev_departure_text
+      yesterdayLabel = hdRef.prev_departure_text
 
     }
+
+    return {
+      recents,
+      recentDepText,
+      recentHeadways,
+      recentVehicleRefs,
+      recentDepartures,
+      previousDepartures,
+      yesterday,
+      previousHeadways,
+      previousVehicleRefs,
+      yesterdayLabel,
+      recentsRating,
+      prevDeparturesRating,
+      overallRating,
+    }
+  }
+
+  render() {
+    if (this.props.ui.loading && this.props.realTimeDetails.items.length === 0) {
+      return <Loader absolute />
+    }
+
+    const loadingState = this.props.ui
+    const {
+      routeName,
+      routeId,
+      routeDirection,
+      stopId,
+      stopName,
+      stopsAwayText,
+      minutesAwayText,
+      progressStatusText,
+      anticipatedDepVehicleRef,
+    } = this.getHeaderAndRealTimeData()
+
+    const {
+      recents,
+      recentDepText,
+      recentHeadways,
+      recentVehicleRefs,
+      recentDepartures,
+      previousDepartures,
+      yesterday,
+      previousHeadways,
+      previousVehicleRefs,
+      yesterdayLabel,
+      recentsRating,
+      prevDeparturesRating,
+      overallRating,
+    } = this.getDepartureData()
+
 
     return (
       <div className='bus-stop-detail'>
@@ -243,7 +302,7 @@ class BusStopDetailPage extends Component {
           yesterday={yesterday}
           previousHeadways={previousHeadways}
           previousVehicleRefs={previousVehicleRefs}
-          yesterdayLabel={prevText}
+          yesterdayLabel={yesterdayLabel}
           recentsRating={recentsRating}
           prevDeparturesRating={prevDeparturesRating}
           overallRating={overallRating}

--- a/src/components/BusStopDetailPage.js
+++ b/src/components/BusStopDetailPage.js
@@ -48,6 +48,24 @@ class BusStopDetailPage extends Component {
 
   createAnticipatedDeparture = () => {
     console.log('create anticipated departure!')
+    // {
+    //   id(pin): null
+    //   stop_ref(pin): "MTA_401905"
+    //   line_ref(pin): "MTA NYCT_M86+"
+    //   departure_time(pin): "2019-03-10T14:14:01.000Z"
+    //   created_at(pin): null
+    //   updated_at(pin): null
+    //   vehicle_ref(pin): "MTA NYCT_6097"
+    //   bus_stop_id(pin): null
+    //   headway(pin): 459
+    //   previous_departure_id(pin): null
+    //   block_ref(pin): null
+    //   dated_vehicle_journey_ref(pin): null
+    //   interpolated(pin): false
+    //   anticipated: true              <--- !!!
+    //   direction_ref(pin): null
+    // }
+
   }
 
   render() {

--- a/src/components/BusStopDetailPage.js
+++ b/src/components/BusStopDetailPage.js
@@ -118,9 +118,9 @@ class BusStopDetailPage extends Component {
         routeName = routeRef.shortName
       }
       // get stop name
-      let stopRef = routeData.references.stops.find((stopRef) => stopRef.id === stopRef)
-      if (stopRef) {
-        stopName = stopRef.name
+      let stopInfo = routeData.references.stops.find((stopObj) => stopObj.id === stopRef)
+      if (stopInfo) {
+        stopName = stopInfo.name
       }
     }
 

--- a/src/components/BusStopDetailPage.js
+++ b/src/components/BusStopDetailPage.js
@@ -15,12 +15,12 @@ class BusStopDetailPage extends Component {
 
   componentDidMount() {
 
-    const routeId = this.props.match.params.id
+    const lineRef = this.props.match.params.id
     const stopId = this.props.match.params.stop
 
     // If we're just loading the app from this page, get all our data.
     if (!this.props.stopLists.firstRequestSent) {
-      this.props.fetchStopList(routeId)
+      this.props.fetchStopList(lineRef)
     }
     if (!this.props.realTimeDetails.firstRequestSent) {
       this.props.fetchRealTimeDetail(stopId)
@@ -28,7 +28,7 @@ class BusStopDetailPage extends Component {
     if (!this.props.historicalDepartures.firstRequestSent) {
       this.props.fetchHistoricalDeparture({
       stopRef: stopId,
-      lineRef: routeId,
+      lineRef: lineRef,
       })
     }
     this.reinsertAnticipatedDepartures()
@@ -39,7 +39,7 @@ class BusStopDetailPage extends Component {
     // Historical departures: every minute (matches how often the API creates them)
     this.getNextHistoricalDepartures = setInterval(this.props.fetchHistoricalDeparture, 60000, {
       stopRef: stopId,
-      lineRef: routeId,
+      lineRef: lineRef,
     })
     // have to put this in its own function so that this.props.anticipatedDepartures.items is up to date.
     this.getNextAnticipatedDepartures = setInterval(this.reinsertAnticipatedDepartures, 9000);
@@ -115,13 +115,13 @@ class BusStopDetailPage extends Component {
 
   getHeaderAndRealTimeData = () => {
 
-    const routeId = this.props.match.params.id
+    const lineRef = this.props.match.params.id
     const stopId = this.props.match.params.stop
 
     var routeData, routeName, stopName, routeDirection;
     var stopsAwayText, minutesAwayText, expectedDepartureTime, progressStatusText;
 
-    let foundStopList = this.props.stopLists.items.find((stopList) => stopList.data && stopList.data.entry.routeId === routeId)
+    let foundStopList = this.props.stopLists.items.find((stopList) => stopList.data && stopList.data.entry.routeId === lineRef)
     if (!foundStopList) {
       // console.log('!foundStopList')
     } else {
@@ -144,8 +144,8 @@ class BusStopDetailPage extends Component {
     var anticipatedDepVehicleRef;
     // realTimeDetails: Filter to just the stopRef we care about
     let rtdRefs = this.props.realTimeDetails.items.filter((rtdRef) => rtdRef.stopRef === stopId);
-    // Now find the first vehicle that matches our routeId
-    let foundRtdRef = rtdRefs.find((rtdRef) => rtdRef.lineRef === routeId);
+    // Now find the first vehicle that matches our lineRef
+    let foundRtdRef = rtdRefs.find((rtdRef) => rtdRef.lineRef === lineRef);
     if (!foundRtdRef) {
       // console.log('!foundRtdRef')
       stopsAwayText = "No vehicles found"
@@ -170,7 +170,7 @@ class BusStopDetailPage extends Component {
 
     return {
       routeName,
-      routeId,
+      lineRef,
       routeDirection,
       stopId,
       stopName,
@@ -183,7 +183,7 @@ class BusStopDetailPage extends Component {
 
   getDepartureData = () => {
 
-    const routeId = this.props.match.params.id
+    const lineRef = this.props.match.params.id
     const stopId = this.props.match.params.stop
 
     // HISTORICAL DEPARTURE DATA
@@ -196,7 +196,7 @@ class BusStopDetailPage extends Component {
     var yesterdayLabel, recentHeadways, previousHeadways, previousTimestamps, recentDepText;
     var recentsRating, prevDeparturesRating, overallRating;
 
-    let hdRef = this.props.historicalDepartures.items.find((dep) => dep.line_ref === routeId && dep.stop_ref === stopId)
+    let hdRef = this.props.historicalDepartures.items.find((dep) => dep.line_ref === lineRef && dep.stop_ref === stopId)
     if (hdRef) {
       // Recent departure data
       recentDepartures = hdRef.recents
@@ -251,7 +251,7 @@ class BusStopDetailPage extends Component {
     const loadingState = this.props.ui
     const {
       routeName,
-      routeId,
+      lineRef,
       routeDirection,
       stopId,
       stopName,
@@ -283,7 +283,7 @@ class BusStopDetailPage extends Component {
         <BusRouteHeader
           loadingState={loadingState}
           routeName={routeName}
-          routeId={routeId}
+          routeId={lineRef}
           routeDirection={routeDirection}
           stopNum={stopId}
           stopName={stopName}

--- a/src/components/BusStopDetailPage.js
+++ b/src/components/BusStopDetailPage.js
@@ -38,6 +38,7 @@ class BusStopDetailPage extends Component {
       lineRef: routeId,
       })
     }
+    this.reinsertAnticipatedDepartures()
 
     // Poll the API regularly to update data
     // Realtime data: every 9 seconds
@@ -47,12 +48,29 @@ class BusStopDetailPage extends Component {
       stopRef: stopId,
       lineRef: routeId,
     })
+    // have to put this in its own function so that this.props.anticipatedDepartures.items is up to date.
+    this.getNextAnticipatedDepartures = setInterval(this.reinsertAnticipatedDepartures, 9000);
   }
 
   componentWillUnmount() {
     clearInterval(this.getNextRealtimeData)
     clearInterval(this.getNextHistoricalDepartures)
+    clearInterval(this.getNextAnticipatedDepartures)
   }
+
+  reinsertAnticipatedDepartures = () => {
+    this.props.insertAnticipatedDepartures({
+      anticipatedDepartures: this.props.anticipatedDepartures.items,
+    })
+  }
+
+  // componentDidUpdate(prevProps, prevState) {
+  //   if (this.props.historicalDepartures.items.length < 1 || prevProps.historicalDepartures.items.length < 1) return;
+  //   if (prevProps.historicalDepartures.items[0].recents[0] !== this.props.historicalDepartures.items[0].recents[0]) {
+  //     console.log('reinserting anticipated departures', this.props.anticipatedDepartures)
+  //     this.props.insertAnticipatedDepartures({anticipatedDepartures: this.props.anticipatedDepartures.items})
+  //   }
+  // }
 
   createAnticipatedDeparture = (vehicleRef) => {
     console.log('create anticipated departure!')
@@ -102,7 +120,7 @@ class BusStopDetailPage extends Component {
         previous_departure_id: null,
         block_ref: null,
         dated_vehicle_journey_ref: null,
-        interpolated: false,
+        interpolated: true,
         anticipated: true,
         direction_ref: null,
       }

--- a/src/components/BusStopDetailPage.js
+++ b/src/components/BusStopDetailPage.js
@@ -3,6 +3,7 @@ import { withRouter } from 'react-router-dom'
 import { connect } from 'react-redux'
 import { fetchRealTimeDetail } from './../redux/actions/realTimeDetails'
 import { fetchHistoricalDeparture } from './../redux/actions/historicalDepartures'
+import { addAnticipatedDeparture } from './../redux/actions/anticipatedDepartures'
 import { fetchStopList } from './../redux/actions/stopLists'
 import { setLoader, clearLoader } from './../redux/actions/ui'
 import moment from 'moment'
@@ -65,6 +66,26 @@ class BusStopDetailPage extends Component {
     //   anticipated: true              <--- !!!
     //   direction_ref(pin): null
     // }
+
+    this.props.addAnticipatedDeparture({
+      anticipatedDeparture: {
+        id: null,
+        stop_ref: "MTA_401905",
+        line_ref: "MTA NYCT_M86+",
+        departure_time: "2019-03-10T14:14:01.000Z",
+        created_at: null,
+        updated_at: null,
+        vehicle_ref: "MTA NYCT_6097",
+        bus_stop_id: null,
+        headway: 459,
+        previous_departure_id: null,
+        block_ref: null,
+        dated_vehicle_journey_ref: null,
+        interpolated: false,
+        anticipated: true,
+        direction_ref: null,
+      }
+    })
 
   }
 
@@ -215,6 +236,7 @@ const mapDispatchToProps = {
   fetchStopList,
   setLoader,
   clearLoader,
+  addAnticipatedDeparture,
 }
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(BusStopDetailPage));

--- a/src/components/BusStopDetailPage.js
+++ b/src/components/BusStopDetailPage.js
@@ -28,27 +28,17 @@ class BusStopDetailPage extends Component {
     if (!this.props.historicalDepartures.firstRequestSent) {
       this.props.fetchHistoricalDeparture({ stopRef, lineRef })
     }
-    this.reinsertAnticipatedDepartures()
 
     // Poll the API regularly to update data
     // Realtime data: every 9 seconds
     this.getNextRealtimeData = setInterval(this.props.fetchRealTimeDetail, 9000, stopRef)
     // Historical departures: every minute (matches how often the API creates them)
     this.getNextHistoricalDepartures = setInterval(this.props.fetchHistoricalDeparture, 60000, { stopRef, lineRef })
-    // have to put this in its own function so that this.props.anticipatedDepartures.items is up to date.
-    this.getNextAnticipatedDepartures = setInterval(this.reinsertAnticipatedDepartures, 9000);
   }
 
   componentWillUnmount() {
     clearInterval(this.getNextRealtimeData)
     clearInterval(this.getNextHistoricalDepartures)
-    clearInterval(this.getNextAnticipatedDepartures)
-  }
-
-  reinsertAnticipatedDepartures = () => {
-    this.props.insertAnticipatedDepartures({
-      anticipatedDepartures: this.props.anticipatedDepartures.items,
-    })
   }
 
   createAnticipatedDeparture = (vehicleRef) => {

--- a/src/components/BusStopDetailPage.js
+++ b/src/components/BusStopDetailPage.js
@@ -89,7 +89,7 @@ class BusStopDetailPage extends Component {
         previous_departure_id: null,
         block_ref: null,
         dated_vehicle_journey_ref: null,
-        interpolated: true,
+        interpolated: false,
         anticipated: true,
         direction_ref: null,
       }
@@ -145,7 +145,11 @@ class BusStopDetailPage extends Component {
       if (expectedDepartureTime === undefined) {
         minutesAwayText = "not provided"
       } else {
-        let expectedDepText = moment(expectedDepartureTime).format('LT')
+        var expectedDepText = moment(expectedDepartureTime).format('LT')
+        if (Date.parse(expectedDepartureTime) - new Date() < 10000) {
+          expectedDepText = moment(expectedDepartureTime).format('LTS')
+        }
+        // console.log(Date.parse(expectedDepartureTime) - new Date())
         minutesAwayText = moment(expectedDepartureTime).fromNow();
         minutesAwayText += ` (${expectedDepText})`
       }

--- a/src/components/BusStopDetailPage.js
+++ b/src/components/BusStopDetailPage.js
@@ -183,7 +183,7 @@ class BusStopDetailPage extends Component {
     if (hdRef) {
       // Recent departure data
       recentDepartures = hdRef.recents
-      let recentTimestamps = hdRef.recent_departure_times.slice(0, 8) // first 8 elements
+      let recentTimestamps = hdRef.recents.slice(0, 8).map((d) => d.departure_time) // first 8 elements
       recentHeadways = recentDepartures.map((hd) => Math.round(hd.headway / 60))
       let currentHeadway = (new Date() - Date.parse(recentTimestamps[0])) / 1000 / 60
       currentHeadway = Math.round(currentHeadway)
@@ -262,6 +262,7 @@ const mapDispatchToProps = {
   setLoader,
   clearLoader,
   addAnticipatedDeparture,
+  insertAnticipatedDepartures,
 }
 
 export default withRouter(connect(mapStateToProps, mapDispatchToProps)(BusStopDetailPage));

--- a/src/components/DepartureGraph.js
+++ b/src/components/DepartureGraph.js
@@ -115,6 +115,7 @@ const DepartureGraph = (props) => {
       {departures.map((departure, idx) => {
         let headway = headways[idx]
         let hwWidth = headway * 8
+        if (!headway) hwWidth = 8;
         let crowdDots = false
         let lastHeadway = (idx === departures.length - 1)
         if (headway < 3 && idx > 0) {

--- a/src/components/DepartureGraph.js
+++ b/src/components/DepartureGraph.js
@@ -40,6 +40,10 @@ const StyledDepartureDot = styled.div`
     background-color: #d8d8d8;
     color: #797878;
   }
+  &.white {
+    background-color: #fdfdfd;
+    color: #797878;
+  }
 `
 const StyledDepartureHeadway = styled.div`
   font-family: 'Asap';
@@ -97,6 +101,16 @@ function doNothing() {
   return null;
 }
 
+function getDotClassName(departure) {
+  if (departure.interpolated) {
+    return "grayscale"
+  }
+  if (departure.anticipated) {
+    return "white"
+  }
+  return ""
+}
+
 const DepartureGraph = (props) => {
   // headways = [5, 6, 15, 22, 8] - minutes of wait time in between each departure
   // times = ['6:56pm', '6:33pm', ...]
@@ -131,7 +145,7 @@ const DepartureGraph = (props) => {
                 </StyledDiv>
               </StyledDepartureHeadway>
             }
-            <StyledDepartureDot onClick={doNothing} key={Date.now()} className={departure.interpolated ? "grayscale" : ""}>
+            <StyledDepartureDot onClick={doNothing} key={Date.now()} className={getDotClassName(departure)}>
               <StyledTooltip>
                 <div>
                   {times[idx]}<br />

--- a/src/components/RealTimeDetails.js
+++ b/src/components/RealTimeDetails.js
@@ -5,7 +5,7 @@ const RealTimeDetails = (props) => (
   <RoundRect className='bus-departure-details'>
     <>
     <p>Expected departure: {props.minutesAway}</p>
-    <p>{props.stopsAway}</p>
+    <p>{props.vehicleNum ? `Vehicle # ${props.vehicleNum.split("_")[1]} is ` : null}{props.stopsAway}</p>
     {props.progressStatus &&
       <p>{props.progressStatus}</p>
     }

--- a/src/redux/actions/anticipatedDepartures.js
+++ b/src/redux/actions/anticipatedDepartures.js
@@ -7,10 +7,10 @@ export const ADD_ANTICIPATED_DEPARTURE = `${ANTICIPATED_DEPARTURES} ADD`;
 
 // action creators
 
-export const addAnticipatedDeparture = ({historicalDeparture}) => {
+export const addAnticipatedDeparture = ({anticipatedDeparture, stopRef, lineRef}) => {
   return {
     type: ADD_ANTICIPATED_DEPARTURE,
-    payload: historicalDeparture,
+    payload: anticipatedDeparture,
     meta: {stopRef, lineRef},
   }
 }

--- a/src/redux/actions/anticipatedDepartures.js
+++ b/src/redux/actions/anticipatedDepartures.js
@@ -1,0 +1,23 @@
+// model name
+export const ANTICIPATED_DEPARTURES = '[AnticipatedDepartures]';
+
+// action types
+export const ADD_ANTICIPATED_DEPARTURE = `${ANTICIPATED_DEPARTURES} ADD`;
+// export const PURGE_ANTICIPATED_DEPARTURES = `${ANTICIPATED_DEPARTURES} PURGE`;
+
+// action creators
+
+export const addAnticipatedDeparture = ({historicalDeparture}) => {
+  return {
+    type: ADD_ANTICIPATED_DEPARTURE,
+    payload: historicalDeparture,
+    meta: {stopRef, lineRef},
+  }
+}
+
+// export const purgeAnticipatedDepartures = ({stopRef, lineRef}) => {
+//   return {
+//     type: PURGE_ANTICIPATED_DEPARTURES,
+//     payload: {stopRef, lineRef},
+//   }
+// }

--- a/src/redux/actions/historicalDepartures.js
+++ b/src/redux/actions/historicalDepartures.js
@@ -3,7 +3,7 @@ export const HISTORICAL_DEPARTURES = '[HistoricalDepartures]';
 
 // action types
 export const FETCH_HISTORICAL_DEPARTURE = `${HISTORICAL_DEPARTURES} FETCH`;
-export const ADD_HISTORICAL_DEPARTURE = `${HISTORICAL_DEPARTURES} ADD`;
+export const ADD_HISTORICAL_DEPARTURE = `${HISTORICAL_DEPARTURES} ADD`; // this actually adds a set of departures, not a single departure
 export const PURGE_HISTORICAL_DEPARTURES = `${HISTORICAL_DEPARTURES} PURGE`;
 export const SKIP_DEPARTURE_FETCH = `${HISTORICAL_DEPARTURES} SKIP FETCH`;
 

--- a/src/redux/actions/historicalDepartures.js
+++ b/src/redux/actions/historicalDepartures.js
@@ -6,6 +6,7 @@ export const FETCH_HISTORICAL_DEPARTURE = `${HISTORICAL_DEPARTURES} FETCH`;
 export const ADD_HISTORICAL_DEPARTURE = `${HISTORICAL_DEPARTURES} ADD`; // this actually adds a set of departures, not a single departure
 export const PURGE_HISTORICAL_DEPARTURES = `${HISTORICAL_DEPARTURES} PURGE`;
 export const SKIP_DEPARTURE_FETCH = `${HISTORICAL_DEPARTURES} SKIP FETCH`;
+export const INSERT_ANTICIPATED_DEPARTURES = `${HISTORICAL_DEPARTURES} INSERT ANTICIPATED DEPARTURES`
 
 // action creators
 
@@ -33,5 +34,12 @@ export const purgeHistoricalDepartures = ({stopRef, lineRef}) => {
   return {
     type: PURGE_HISTORICAL_DEPARTURES,
     payload: {stopRef, lineRef},
+  }
+}
+
+export const insertAnticipatedDepartures = ({anticipatedDepartures}) => {
+  return {
+    type: INSERT_ANTICIPATED_DEPARTURES,
+    payload: anticipatedDepartures,
   }
 }

--- a/src/redux/middleware/core/normalize.js
+++ b/src/redux/middleware/core/normalize.js
@@ -43,6 +43,7 @@ function normalizeData(action) {
         destinationName: mvj.DestinationName[0],
         stopRef: mvj.MonitoredCall.StopPointRef,
         lineRef: mvj.LineRef,
+        vehicleRef: mvj.VehicleRef,
         responseTimestamp: action.payload.Siri.ServiceDelivery.ResponseTimestamp,
         distanceFromStop: mvj.MonitoredCall.DistanceFromStop,
       }

--- a/src/redux/middleware/feature/anticipatedDepartures.js
+++ b/src/redux/middleware/feature/anticipatedDepartures.js
@@ -1,5 +1,5 @@
-import { ANTICIPATED_DEPARTURES, ADD_ANTICIPATED_DEPARTURE, addAnticipatedDeparture } from '../../actions/anticipatedDepartures.js'
-import { INSERT_ANTICIPATED_DEPARTURES, insertAnticipatedDepartures } from '../../actions/historicalDepartures.js'
+import { ADD_ANTICIPATED_DEPARTURE } from '../../actions/anticipatedDepartures.js'
+import { insertAnticipatedDepartures } from '../../actions/historicalDepartures.js'
 
 export const anticipatedDeparturesMiddleware = () => (next) => (action) => {
   next(action);

--- a/src/redux/middleware/feature/anticipatedDepartures.js
+++ b/src/redux/middleware/feature/anticipatedDepartures.js
@@ -1,0 +1,18 @@
+import { ANTICIPATED_DEPARTURES, ADD_ANTICIPATED_DEPARTURE, addAnticipatedDeparture } from '../../actions/anticipatedDepartures.js'
+import { INSERT_ANTICIPATED_DEPARTURES, insertAnticipatedDepartures } from '../../actions/historicalDepartures.js'
+
+export const anticipatedDeparturesMiddleware = () => (next) => (action) => {
+  next(action);
+
+  switch(action.type) {
+
+    case ADD_ANTICIPATED_DEPARTURE:
+      next(insertAnticipatedDepartures({
+        anticipatedDepartures: [action.payload],
+      }));
+    
+    default:
+      return null;
+
+  }
+}

--- a/src/redux/middleware/feature/anticipatedDepartures.js
+++ b/src/redux/middleware/feature/anticipatedDepartures.js
@@ -10,7 +10,8 @@ export const anticipatedDeparturesMiddleware = () => (next) => (action) => {
       next(insertAnticipatedDepartures({
         anticipatedDepartures: [action.payload],
       }));
-    
+      break;
+
     default:
       return null;
 

--- a/src/redux/middleware/feature/historicalDepartures.js
+++ b/src/redux/middleware/feature/historicalDepartures.js
@@ -1,8 +1,8 @@
-import { HISTORICAL_DEPARTURES, FETCH_HISTORICAL_DEPARTURE, addHistoricalDeparture, purgeHistoricalDepartures } from '../../actions/historicalDepartures.js'
+import { HISTORICAL_DEPARTURES, FETCH_HISTORICAL_DEPARTURE, addHistoricalDeparture, purgeHistoricalDepartures, insertAnticipatedDepartures } from '../../actions/historicalDepartures.js'
 import { apiRequest, API_SUCCESS, API_ERROR } from '../../actions/api'
 import { BUS_STOPS_URL } from '../../../constants'
 
-export const historicalDeparturesMiddleware = () => (next) => (action) => {
+export const historicalDeparturesMiddleware = (store) => (next) => (action) => {
   next(action);
 
   switch(action.type) {
@@ -21,8 +21,14 @@ export const historicalDeparturesMiddleware = () => (next) => (action) => {
         stopRef: action.payload.stop_ref,
         lineRef: action.payload.line_ref,
       }
-      next(purgeHistoricalDepartures(payload))
-      next(addHistoricalDeparture({historicalDeparture: action.payload}))
+      // Purge existing historicalDepartures for that stop/lineRef
+      next(purgeHistoricalDepartures(payload));
+      // Replace them with the just-retrieved departures
+      next(addHistoricalDeparture({historicalDeparture: action.payload}));
+      // Reinsert the anticipated departures from the store
+      const anticipatedDepartures = store.getState().anticipatedDepartures.items
+      console.log('inserting: ', anticipatedDepartures)
+      next(insertAnticipatedDepartures({ anticipatedDepartures }))
       break;
     case `${HISTORICAL_DEPARTURES} ${API_ERROR}`:
       console.log('API ERROR', action.payload)

--- a/src/redux/middleware/feature/historicalDepartures.js
+++ b/src/redux/middleware/feature/historicalDepartures.js
@@ -27,7 +27,7 @@ export const historicalDeparturesMiddleware = (store) => (next) => (action) => {
       next(addHistoricalDeparture({historicalDeparture: action.payload}));
       // Reinsert the anticipated departures from the store
       const anticipatedDepartures = store.getState().anticipatedDepartures.items
-      console.log('inserting: ', anticipatedDepartures)
+      // console.log('inserting: ', anticipatedDepartures)
       next(insertAnticipatedDepartures({ anticipatedDepartures }))
       break;
     case `${HISTORICAL_DEPARTURES} ${API_ERROR}`:

--- a/src/redux/reducers/anticipatedDepartures.reducer.js
+++ b/src/redux/reducers/anticipatedDepartures.reducer.js
@@ -1,0 +1,19 @@
+import { ADD_ANTICIPATED_DEPARTURE } from '../actions/anticipatedDepartures'
+
+const anticipatedDeparturesState = {
+  items: [],
+}
+
+export const anticipatedDeparturesReducer = (state = anticipatedDeparturesState, action) => {
+  let newState;
+  switch (action.type) {
+    case ADD_ANTICIPATED_DEPARTURE:
+      let newAnticipatedDeparture = action.payload
+      newState = {
+        items: [...state.items, newAnticipatedDeparture],
+      }
+      return Object.assign({}, state, newState)
+    default:
+    return state
+  }
+}

--- a/src/redux/reducers/historicalDepartures.reducer.js
+++ b/src/redux/reducers/historicalDepartures.reducer.js
@@ -44,15 +44,14 @@ export const historicalDeparturesReducer = (state = historicalDeparturesState, a
           itemsWithoutHdRef = newState.items.filter((item) => item !== hdRef)
           newRecents = [anticipatedDeparture, ...hdRef.recents.slice()]
           console.log(newRecents[0])
-          if (newRecents[0].vehicleRef === newRecents[1].vehicleRef) {
+          if (newRecents[0].vehicle_ref === newRecents[1].vehicle_ref) {
             // If the real departure is present, don't add the anticipated departure
+            console.log('shifting: ', [newRecents[0].vehicle_ref, newRecents[1].vehicle_ref])
             newRecents.shift()
           }
           newHdRef = Object.assign({}, hdRef, {recents: newRecents})
-          console.log(newHdRef)
         }
         if (itemsWithoutHdRef) {
-          console.log('Inserting anticipated departures')
           newState = {
             items: [newHdRef, ...itemsWithoutHdRef]
           }

--- a/src/redux/reducers/historicalDepartures.reducer.js
+++ b/src/redux/reducers/historicalDepartures.reducer.js
@@ -42,8 +42,8 @@ export const historicalDeparturesReducer = (state = historicalDeparturesState, a
           // Without mutating state, remove the first element from hdRef.recents and replace it with anticipatedDeparture
           itemsWithoutHdRef = null;
           itemsWithoutHdRef = newState.items.filter((item) => item !== hdRef)
-          newRecents = [anticipatedDeparture, ...hdRef.recents.slice()]
-          if (newRecents[0].vehicle_ref === newRecents[1].vehicle_ref) {
+          newRecents = [anticipatedDeparture, ...hdRef.recents.filter((hd) => !('anticipated' in hd))] // only allow a single anticipated departure
+          if (newRecents[0].vehicle_ref === newRecents[1].vehicle_ref || newRecents[0].vehicle_ref === newRecents[2].vehicle_ref) {
             // If the real departure is present, don't add the anticipated departure
             // console.log('shifting: ', [newRecents[0], newRecents[1]])
             newRecents.shift()

--- a/src/redux/reducers/historicalDepartures.reducer.js
+++ b/src/redux/reducers/historicalDepartures.reducer.js
@@ -29,18 +29,26 @@ export const historicalDeparturesReducer = (state = historicalDeparturesState, a
       }
       return Object.assign({}, state, newState)
     case INSERT_ANTICIPATED_DEPARTURES:
+      let stopRef, lineRef, newRecents, hdRef, newHdRef, itemsWithoutHdRef;
       newState = {
         items: [...state.items]
       }
-      let stopRef, lineRef, newRecents, hdRef;
-      action.anticipatedDepartures.forEach((anticipatedDeparture) => {
+      action.payload.forEach((anticipatedDeparture) => {
         stopRef = anticipatedDeparture.stop_ref
         lineRef = anticipatedDeparture.line_ref
         hdRef = null;
         hdRef = newState.items.find((dep) => dep.line_ref === lineRef && dep.stop_ref === stopRef)
         if (hdRef) {
           // Without mutating state, remove the first element from hdRef.recents and replace it with anticipatedDeparture
+          itemsWithoutHdRef = null;
+          itemsWithoutHdRef = newState.items.filter((item) => item !== hdRef)
           newRecents = [anticipatedDeparture, ...hdRef.recents.slice()]
+          newHdRef = Object.assign({}, hdRef, {recents: newRecents})
+        }
+        if (itemsWithoutHdRef) {
+          newState = {
+            items: [newHdRef, ...itemsWithoutHdRef]
+          }
         }
       })
       return Object.assign({}, state, newState)

--- a/src/redux/reducers/historicalDepartures.reducer.js
+++ b/src/redux/reducers/historicalDepartures.reducer.js
@@ -1,4 +1,4 @@
-import { ADD_HISTORICAL_DEPARTURE, FETCH_HISTORICAL_DEPARTURE, PURGE_HISTORICAL_DEPARTURES } from '../actions/historicalDepartures'
+import { ADD_HISTORICAL_DEPARTURE, FETCH_HISTORICAL_DEPARTURE, PURGE_HISTORICAL_DEPARTURES, INSERT_ANTICIPATED_DEPARTURES } from '../actions/historicalDepartures'
 
 const historicalDeparturesState = {
   items: [],
@@ -27,6 +27,22 @@ export const historicalDeparturesReducer = (state = historicalDeparturesState, a
       newState = {
         items: filteredItems, // replace current state with filtered state
       }
+      return Object.assign({}, state, newState)
+    case INSERT_ANTICIPATED_DEPARTURES:
+      newState = {
+        items: [...state.items]
+      }
+      let stopRef, lineRef, newRecents, hdRef;
+      action.anticipatedDepartures.forEach((anticipatedDeparture) => {
+        stopRef = anticipatedDeparture.stop_ref
+        lineRef = anticipatedDeparture.line_ref
+        hdRef = null;
+        hdRef = newState.items.find((dep) => dep.line_ref === lineRef && dep.stop_ref === stopRef)
+        if (hdRef) {
+          // Without mutating state, remove the first element from hdRef.recents and replace it with anticipatedDeparture
+          newRecents = [anticipatedDeparture, ...hdRef.recents.slice()]
+        }
+      })
       return Object.assign({}, state, newState)
     default:
     return state

--- a/src/redux/reducers/historicalDepartures.reducer.js
+++ b/src/redux/reducers/historicalDepartures.reducer.js
@@ -43,10 +43,9 @@ export const historicalDeparturesReducer = (state = historicalDeparturesState, a
           itemsWithoutHdRef = null;
           itemsWithoutHdRef = newState.items.filter((item) => item !== hdRef)
           newRecents = [anticipatedDeparture, ...hdRef.recents.slice()]
-          console.log(newRecents[0])
           if (newRecents[0].vehicle_ref === newRecents[1].vehicle_ref) {
             // If the real departure is present, don't add the anticipated departure
-            console.log('shifting: ', [newRecents[0].vehicle_ref, newRecents[1].vehicle_ref])
+            // console.log('shifting: ', [newRecents[0], newRecents[1]])
             newRecents.shift()
           }
           newHdRef = Object.assign({}, hdRef, {recents: newRecents})

--- a/src/redux/reducers/historicalDepartures.reducer.js
+++ b/src/redux/reducers/historicalDepartures.reducer.js
@@ -43,9 +43,16 @@ export const historicalDeparturesReducer = (state = historicalDeparturesState, a
           itemsWithoutHdRef = null;
           itemsWithoutHdRef = newState.items.filter((item) => item !== hdRef)
           newRecents = [anticipatedDeparture, ...hdRef.recents.slice()]
+          console.log(newRecents[0])
+          if (newRecents[0].vehicleRef === newRecents[1].vehicleRef) {
+            // If the real departure is present, don't add the anticipated departure
+            newRecents.shift()
+          }
           newHdRef = Object.assign({}, hdRef, {recents: newRecents})
+          console.log(newHdRef)
         }
         if (itemsWithoutHdRef) {
+          console.log('Inserting anticipated departures')
           newState = {
             items: [newHdRef, ...itemsWithoutHdRef]
           }

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -5,6 +5,7 @@ import {busRoutesReducer} from "./reducers/busRoutes.reducer";
 import {stopListsReducer} from './reducers/stopLists.reducer';
 import {realTimeDetailsReducer} from './reducers/realTimeDetails.reducer';
 import {historicalDeparturesReducer} from './reducers/historicalDepartures.reducer'
+import {anticipatedDeparturesReducer} from './reducers/anticipatedDepartures.reducer'
 
 import {uiReducer} from './reducers/ui.reducer'
 
@@ -24,6 +25,7 @@ const rootReducer = combineReducers({
   ui: uiReducer,
   realTimeDetails: realTimeDetailsReducer,
   historicalDepartures: historicalDeparturesReducer,
+  anticipatedDepartures: anticipatedDeparturesReducer,
 })
 
 // create the feature middleware array

--- a/src/redux/store.js
+++ b/src/redux/store.js
@@ -13,6 +13,7 @@ import {busRoutesMiddleware} from './middleware/feature/busRoutes.js';
 import {stopListsMiddleware} from './middleware/feature/stopLists';
 import {realTimeDetailsMiddleware} from './middleware/feature/realTimeDetails'
 import {historicalDeparturesMiddleware} from './middleware/feature/historicalDepartures'
+import {anticipatedDeparturesMiddleware} from './middleware/feature/anticipatedDepartures'
 
 import {apiMiddleware} from './middleware/core/api';
 import {normalizeMiddleware} from './middleware/core/normalize'
@@ -35,6 +36,7 @@ const featureMiddleware = [
   stopListsMiddleware,
   realTimeDetailsMiddleware,
   historicalDeparturesMiddleware,
+  anticipatedDeparturesMiddleware,
 ];
 
 const coreMiddleware = [


### PR DESCRIPTION
Display anticipated departures so that users don't have to wait 2-3 minutes for the API to create the departure.  Anticipated departures show up in white.